### PR TITLE
Force http1 for php curl

### DIFF
--- a/php/zello_server_api.class.php
+++ b/php/zello_server_api.class.php
@@ -399,6 +399,7 @@ class ZelloServerAPI {
 		curl_setopt($curl, CURLOPT_URL, $url);								
 		curl_setopt($curl, CURLOPT_HEADER, false); 	
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 		curl_setopt($curl, CURLOPT_HTTPHEADER, array(
 			"Content-Type" => "application/x-www-form-urlencoded")
 		);


### PR DESCRIPTION
I was able to reproduce that under php 7 which has newer curl and fails to POST to http2 as you've discovered. This fix will help manatts while we figure out why it's not working under http2